### PR TITLE
Make sure we pass the callUUID on most event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,26 @@ After all works are done, remember to call `RNCallKit.startCall(uuid, calleeNumb
 User answer the incoming call
 
 Do your normal `Answering` actions here
+**data**:
+
+```javascript
+{
+  callUUID: 'f0ee907b-6dbd-45a8-858a-903decb198f8' // The UUID of the call that is to be answered
+}
+```
 
 ### - endCall
 
 User finish the call
 
 Do your normal `Hang Up` actions here
+**data**:
+
+```javascript
+{
+  callUUID: 'f0ee907b-6dbd-45a8-858a-903decb198f8' // The UUID of the call that is to be hung
+}
+```
 
 ### - didActivateAudioSession
 

--- a/index.js
+++ b/index.js
@@ -29,12 +29,12 @@ export default class RNCallKit {
         } else if (type === 'answerCall') {
             listener = _RNCallKitEmitter.addListener(
                 RNCallKitPerformAnswerCallAction,
-                () => { handler();}
+                (data) => { handler(data);}
             );
         } else if (type === 'endCall') {
             listener = _RNCallKitEmitter.addListener(
                 RNCallKitPerformEndCallAction,
-                () => { handler(); }
+                (data) => { handler(data); }
             );
         } else if (type === 'didActivateAudioSession') {
             listener = _RNCallKitEmitter.addListener(

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -356,7 +356,7 @@ continueUserActivity:(NSUserActivity *)userActivity
     if (![self lessThanIos10_2]) {
         [self configureAudioSession];
     }
-    [self sendEventWithName:RNCallKitPerformAnswerCallAction body:nil];
+    [self sendEventWithName:RNCallKitPerformAnswerCallAction body:@{ @"callUUID": action.callUUID.UUIDString }];
     [action fulfill];
 }
 
@@ -366,7 +366,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 #ifdef DEBUG
     NSLog(@"[RNCallKit][CXProviderDelegate][provider:performEndCallAction]");
 #endif
-    [self sendEventWithName:RNCallKitPerformEndCallAction body:nil];
+    [self sendEventWithName:RNCallKitPerformEndCallAction body:@{ @"callUUID": action.callUUID.UUIDString }];
     [action fulfill];
 }
 


### PR DESCRIPTION
If we are handling multiple calls, this should be very important so the app can track which call is being acted upon.