### PR TITLE
Method for ending all calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,11 @@ export default class RNCallKit {
         _RNCallKit.endCall(uuid);
     }
 
+    static endAllCalls() {
+        if (Platform.OS !== 'ios') return;
+        _RNCallKit.endAllCalls();
+    }
+
     /*
     static setHeldCall(uuid, onHold) {
         if (Platform.OS !== 'ios') return;

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -144,6 +144,18 @@ RCT_EXPORT_METHOD(endCall:(NSString *)uuidString)
     [self requestTransaction:transaction];
 }
 
+RCT_EXPORT_METHOD(endAllCalls)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKit][endAllCalls] calls = %@", self.callKitCallController.callObserver.calls);
+#endif
+    for (CXCall *call in self.callKitCallController.callObserver.calls) {
+        CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:call.UUID];
+        CXTransaction *transaction = [[CXTransaction alloc] initWithAction:endCallAction];
+        [self requestTransaction:transaction];
+    }
+}
+
 RCT_EXPORT_METHOD(setHeldCall:(NSString *)uuidString onHold:(BOOL)onHold)
 {
 #ifdef DEBUG


### PR DESCRIPTION
This should solve the problem of callKit not closing due to the following error: 
`Error Domain=com.apple.CallKit.error.requesttransaction Code=4` ( issue #3 )
As far as I know the error with `code 4` means that no call matching the callUUID that user requested was found. And it's impossible to get this error if we just end all of them :) 
