### PR TITLE
Fix iOS Yellow box warning RNCallKit requires main queue setup since it overrides `init`

### DIFF
--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -484,4 +484,9 @@ continueUserActivity:(NSUserActivity *)userActivity
     [action fulfill];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
When using the master branch I get this warning in my emulator:

![image](https://user-images.githubusercontent.com/943430/49350289-c2c45c80-f6f1-11e8-9426-7ac65a4f5eec.png)

By implementing this requiresMainQueueSetup method in RNCallKit the warning disappears.