### PR TITLE
Add ReportUpdatedCall Feature + Bug Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ export default class RNCallKit {
         _RNCallKit.endAllCalls();
     }
 
-    static setMutedCAll(uuid, muted) {
+    static setMutedCall(uuid, muted) {
         if (Platform.OS !== 'ios') return;
         _RNCallKit.setMutedCall(uuid, muted);
     }

--- a/index.js
+++ b/index.js
@@ -82,6 +82,12 @@ export default class RNCallKit {
         : Promise.reject('RNCallKit.checkSpeaker was called from unsupported OS');
     }
 
+    static reportUpdatedCall(uuid, localizedCallerName?: String) {
+      return Platform.OS === 'ios'
+        ? _RNCallKit.reportUpdatedCall(uuid, localizedCallerName)
+        : Promise.reject('RNCallKit.reportUpdatedCall was called from unsupported OS');
+    }
+
     /*
     static setHeldCall(uuid, onHold) {
         if (Platform.OS !== 'ios') return;

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -240,6 +240,7 @@ RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted)
                 CXStartCallAction *startCallAction = [transaction.actions firstObject];
                 CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
                 callUpdate.remoteHandle = startCallAction.handle;
+                callUpdate.localizedCallerName = startCallAction.contactIdentifier;
                 callUpdate.supportsDTMF = YES;
                 callUpdate.supportsHolding = NO;
                 callUpdate.supportsGrouping = NO;

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -422,6 +422,19 @@ continueUserActivity:(NSUserActivity *)userActivity
     [action fulfill];
 }
 
+// Update call contact info
+RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NSString *)contactIdentifier)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKit][reportUpdatedCall] contactIdentifier = %i", contactIdentifier);
+#endif
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.localizedCallerName = contactIdentifier;
+
+    [self.callKitProvider reportCallWithUUID:uuid updated:callUpdate];
+}
+
 // Answering incoming call
 - (void)provider:(CXProvider *)provider performAnswerCallAction:(CXAnswerCallAction *)action
 {

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -241,11 +241,11 @@ RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted)
                 CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
                 callUpdate.remoteHandle = startCallAction.handle;
                 callUpdate.localizedCallerName = startCallAction.contactIdentifier;
+                callUpdate.hasVideo = startCallAction.video;
                 callUpdate.supportsDTMF = YES;
                 callUpdate.supportsHolding = NO;
                 callUpdate.supportsGrouping = NO;
                 callUpdate.supportsUngrouping = NO;
-                callUpdate.hasVideo = NO;
                 [self.callKitProvider reportCallWithUUID:startCallAction.callUUID updated:callUpdate];
             }
         }


### PR DESCRIPTION
- Adds the ability to change the current call's `localizedCallerName`. This is useful for updating call info when other participants join.
- Fixes bug where `startCallAction` would not properly report the `localizedCallerName` passed from the transaction action
- Fixes bug with `setMutedCall` function name. Before it was `setMuteCAll`